### PR TITLE
[Iron Kingdoms] Correcting Investigation attribute to Intellect

### DIFF
--- a/Iron Kingdoms RPG/IKPRG.html
+++ b/Iron Kingdoms RPG/IKPRG.html
@@ -3867,7 +3867,7 @@
                                 <td style="width:60px"><button type='roll' class="sheet-skill_button" name="attr_investigation_gm" value='/w gm &{template:skill} {{Roll= [[ [[2 + @{investigation_boost}]]d6k[[2 + @{investigation_boost}]]sd + [[@{investigation_total}]] ]] }} {{Text= @{investigation_text} (Investigation) }}'></button></td>
                                 <td style="width:100px">
                                     <select class ="sheet-select sheet-clearbox" name="attr_investigation_select" value="0" style="width:100px">
-                                        <option class="sheet-blackfont" value="@{perception}">Perception</option>
+                                        <option class="sheet-blackfont" value="@{intellect}">Intellect</option>
                                     </select>
                                 </td>
                                 <td style="width:60px"><div><input type="number" class="sheet-stats-base" name="attr_investigation_total" value="@{investigation_select} + @{investigation} + @{investigation_misc}" disabled="true" /></div></td>


### PR DESCRIPTION
## Changes / Comments
The Investigation Skill is supposed to be an Intellect skill instead of a Perception one (as stated in Iron Kingdoms Unleased Core Rules, pg.184), updating the field that references which attribute to use to properly reflect that.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
